### PR TITLE
Improve log streaming in validation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# DeepSeek Teaching Planner
+
+This repository contains a minimal validation pipeline for an AI-powered teaching plan generator. It uses the DeepSeek API for LLM reasoning and a Flask backend to expose progress.
+
+## Requirements
+
+- Python 3.11+
+- `deepseek` Python package
+- `Flask`
+- A valid `DEEPSEEK_API_KEY` environment variable for LLM access
+
+Install dependencies:
+
+```bash
+pip install deepseek Flask
+```
+
+## Running
+
+Start the Flask server:
+
+```bash
+export DEEPSEEK_API_KEY=your-key-here
+python -m educational_planner.app
+```
+
+Use `/start` to begin a job with JSON payload containing `topic`, `student_profile`, and optional `context`.
+
+Poll `/status/<job_id>` for current state, `/logs/<job_id>` to stream reasoning
+messages as they arrive, and `/result/<job_id>` for the final plan once the job
+is complete.

--- a/educational_planner/agents.py
+++ b/educational_planner/agents.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Callable, Tuple, Optional
+
+import deepseek.api
+
+
+def _default_logger(message: str) -> None:
+    print(message)
+
+
+@dataclass
+class TeachingPlanGenerator:
+    api_key: Optional[str] = None
+    logger: Callable[[str], None] = _default_logger
+
+    def _call_llm(self, prompt: str) -> str:
+        api = deepseek.api.DeepSeekAPI(api_key=self.api_key)
+        self.logger(f"LLM Prompt: {prompt}")
+        response = api.chat_completion(prompt)
+        self.logger(f"LLM Response: {response}")
+        return response
+
+    def generate(self, topic: str, student_profile: str, context: str) -> Dict[str, Any]:
+        prompt = (
+            "You are a teaching plan generator. "
+            "Generate a concise JSON teaching outline with numbered teaching directions.\n"
+            f"Topic: {topic}\nStudent profile: {student_profile}\nContext: {context}"
+        )
+        raw = self._call_llm(prompt)
+        try:
+            plan = json.loads(raw)
+        except json.JSONDecodeError:
+            plan = {"plan": raw}
+        return plan
+
+    def revise(self, plan: Dict[str, Any], feedback: str) -> Dict[str, Any]:
+        prompt = (
+            "You are revising a teaching plan based on feedback.\n"
+            f"Current plan: {json.dumps(plan)}\nFeedback: {feedback}\n"
+            "Return only the improved plan in JSON."
+        )
+        raw = self._call_llm(prompt)
+        try:
+            plan = json.loads(raw)
+        except json.JSONDecodeError:
+            plan = {"plan": raw}
+        return plan
+
+
+@dataclass
+class EvaluationAgent:
+    api_key: Optional[str] = None
+    logger: Callable[[str], None] = _default_logger
+
+    def _call_llm(self, prompt: str) -> str:
+        api = deepseek.api.DeepSeekAPI(api_key=self.api_key)
+        self.logger(f"Eval Prompt: {prompt}")
+        response = api.chat_completion(prompt)
+        self.logger(f"Eval Response: {response}")
+        return response
+
+    def evaluate(self, plan: Dict[str, Any]) -> Tuple[int, str]:
+        prompt = (
+            "You are evaluating a teaching plan.\n"
+            f"Plan: {json.dumps(plan)}\n"
+            "Provide a numeric score from 0-100 and a short comment."
+        )
+        raw = self._call_llm(prompt)
+        match = re.search(r"(\d{1,3})", raw)
+        score = int(match.group(1)) if match else 0
+        return score, raw

--- a/educational_planner/app.py
+++ b/educational_planner/app.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import threading
+from flask import Flask, request, jsonify
+
+from .pipeline import run_validation_pipeline
+
+app = Flask(__name__)
+
+jobs: dict[str, dict] = {}
+lock = threading.Lock()
+
+
+def start_job(data: dict) -> str:
+    job_id = os.urandom(8).hex()
+    jobs[job_id] = {
+        "status": "running",
+        "logs": [],
+        "result": None,
+    }
+
+    def run():
+        api_key = os.environ.get("DEEPSEEK_API_KEY")
+
+        def collect(msg: str) -> None:
+            with lock:
+                jobs[job_id]["logs"].append(msg)
+
+        plan, score, _ = run_validation_pipeline(
+            data.get("topic", ""),
+            data.get("student_profile", ""),
+            data.get("context", ""),
+            api_key,
+            logger=collect,
+        )
+        with lock:
+            jobs[job_id]["status"] = "done"
+            jobs[job_id]["result"] = {"plan": plan, "score": score}
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    return job_id
+
+
+@app.route("/start", methods=["POST"])
+def start():
+    data = request.json or {}
+    job_id = start_job(data)
+    return jsonify({"job_id": job_id})
+
+
+@app.route("/status/<job_id>")
+def status(job_id: str):
+    job = jobs.get(job_id)
+    if not job:
+        return jsonify({"error": "not found"}), 404
+    return jsonify({"status": job["status"]})
+
+
+@app.route("/result/<job_id>")
+def result(job_id: str):
+    job = jobs.get(job_id)
+    if not job:
+        return jsonify({"error": "not found"}), 404
+    if job["status"] != "done":
+        return jsonify({"error": "not ready"}), 400
+    return jsonify(job["result"])
+
+
+@app.route("/logs/<job_id>")
+def logs(job_id: str):
+    job = jobs.get(job_id)
+    if not job:
+        return jsonify({"error": "not found"}), 404
+    return jsonify({"logs": job.get("logs", [])})
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/educational_planner/pipeline.py
+++ b/educational_planner/pipeline.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import uuid
+from typing import Dict, Any, Callable, Tuple
+
+from .agents import TeachingPlanGenerator, EvaluationAgent
+
+
+def run_validation_pipeline(
+    topic: str,
+    student_profile: str,
+    context: str,
+    api_key: str | None,
+    logger: Callable[[str], None] | None = None,
+) -> Tuple[Dict[str, Any], int, list[str]]:
+    logs: list[str] = []
+    def log(msg: str) -> None:
+        if logger:
+            logger(msg)
+        logs.append(msg)
+
+    generator = TeachingPlanGenerator(api_key=api_key, logger=log)
+    evaluator = EvaluationAgent(api_key=api_key, logger=log)
+
+    plan = generator.generate(topic, student_profile, context)
+    score, feedback = evaluator.evaluate(plan)
+    log(f"Initial score: {score}")
+
+    while score < 85:
+        plan = generator.revise(plan, feedback)
+        score, feedback = evaluator.evaluate(plan)
+        log(f"Revised score: {score}")
+
+    return plan, score, logs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
+[project]
+name = "educational_planner"
+version = "0.1.0"
+dependencies = [
+    "deepseek",
+    "Flask",
+]
+[tool.pytest.ini_options]
+addopts = "-vv"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,46 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import json
+from educational_planner.app import app
+
+
+def test_start_endpoint(monkeypatch):
+    client = app.test_client()
+
+    # Patch pipeline to avoid real LLM calls
+    def fake_run(*args, **kwargs):
+        return {"lesson": "test"}, 90, ["ok"]
+
+    monkeypatch.setattr("educational_planner.app.run_validation_pipeline", fake_run)
+
+    resp = client.post("/start", json={"topic": "math", "student_profile": "age 8"})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    status_resp = client.get(f"/status/{job_id}")
+    assert status_resp.status_code == 200
+
+
+def test_logs_endpoint(monkeypatch):
+    client = app.test_client()
+
+    def fake_run(*args, logger=None, **kwargs):
+        if logger:
+            logger("step1")
+            logger("step2")
+        return {"lesson": "test"}, 95, ["step1", "step2"]
+
+    monkeypatch.setattr("educational_planner.app.run_validation_pipeline", fake_run)
+
+    resp = client.post("/start", json={"topic": "math", "student_profile": "age 8"})
+    job_id = resp.get_json()["job_id"]
+
+    import time
+    time.sleep(0.05)
+
+    logs_resp = client.get(f"/logs/{job_id}")
+    assert logs_resp.status_code == 200
+    assert logs_resp.get_json()["logs"] == ["step1", "step2"]
+
+    result_resp = client.get(f"/result/{job_id}")
+    assert result_resp.status_code == 200
+    assert result_resp.get_json()["score"] == 95


### PR DESCRIPTION
## Summary
- stream pipeline logs to job state while running
- update README with instructions on fetching progress
- extend tests to cover log streaming

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845a0f1938c83238e7048a4a80a9018